### PR TITLE
Paint refactor

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,63 @@
       href="https://fonts.googleapis.com/css2?family=Recursive:slnt,wght,CASL,CRSV,MONO@-15..0,300..1000,0..1,0..1,0..1&display=swap"
       rel="stylesheet"
     />
+    <script>
+      window.SITEIFY_THEME_SELECTION_KEY = 'siteifyThemeSelection';
+      var DEFAULT_ALTERNATE_THEME = 'haxor';
+
+      function isSiteifySelections (v) {
+        if (typeof v !== 'object' || v === null) return false;
+        const { darkMode, alternateTheme } = v
+        return [darkMode, alternateTheme].every((value) => typeof value === 'boolean');
+      };
+
+      function siteifySelections(userPrefersDark, secondaryToggleEnabled) {
+        const DEFAULT_SELECTIONS = {
+          darkMode: userPrefersDark,
+          alternateTheme: false,
+        };
+        try {
+          const selectionsString = localStorage.getItem(window.SITEIFY_THEME_SELECTION_KEY) || '';
+          const selectionsObj = JSON.parse(selectionsString);
+          if (isSiteifySelections(selectionsObj)) {
+            return secondaryToggleEnabled ? selectionsObj : { ...selectionsObj, alternateTheme: false };
+          } else {
+            throw new Error('selections did not match expected shape');
+          }
+        } catch (e) {
+          console.error(e)
+          return DEFAULT_SELECTIONS;
+        }
+      }
+
+      window.config = function config () {
+        var userPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        var siteifyConfig = window['SITEIFY_CONFIG']
+        var { disabled: secondaryToggleDisabled, className: alternateThemeClass } = siteifyConfig?.secondaryToggle ?? {};
+        var selections = siteifySelections(userPrefersDark, !secondaryToggleDisabled)
+        return { siteifyConfig, alternateThemeClass: alternateThemeClass ?? DEFAULT_ALTERNATE_THEME, ...selections };
+      }
+
+      function initializeTheme() {
+        var configResult = window.config();
+        if (configResult.darkMode) {
+          document.documentElement.classList.add('dark')
+        } else {
+          document.documentElement.classList.add('light')
+        }
+        if (!configResult.siteifyConfig?.secondaryToggle?.disabled && configResult.alternateTheme) {
+          console.log('alternate theme??')
+          document.documentElement.classList.add(configResult.alternateThemeClassName || DEFAULT_ALTERNATE_THEME)
+        }
+      }
+
+      initializeTheme();
+      document.addEventListener("DOMContentLoaded", async () => {
+        await document.fonts.ready;
+        document.body.classList.remove('hidden');
+      });
+
+    </script>
     <style>
       body.hidden {
         visibility: hidden;

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
         }
       }
 
-      window.config = function config () {
+      window.siteifyThemeConfig = function () {
         var userPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
         var siteifyConfig = window['SITEIFY_CONFIG']
         var { disabled: secondaryToggleDisabled, className: alternateThemeClass } = siteifyConfig?.secondaryToggle ?? {};
@@ -50,7 +50,7 @@
       }
 
       function initializeTheme() {
-        var configResult = window.config();
+        var configResult = window.siteifyThemeConfig();
         if (configResult.darkMode) {
           document.documentElement.classList.add('dark')
         } else {

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -14,7 +14,7 @@ function Header() {
     alternateThemeClass,
     darkMode: initialDarkModeValue,
     alternateTheme: initialAlternateThemeValue,
-  } = window.config();
+  } = window.siteifyThemeConfig();
   const [darkMode, setDarkMode] = useState(initialDarkModeValue);
   const [alternateTheme, setAlternateTheme] = useState(initialAlternateThemeValue);
 

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -2,27 +2,11 @@ import { useCallback, useEffect, useState } from 'preact/hooks';
 import { HeaderLink } from '../headerLink';
 import { Toggle } from '../toggle';
 import {
-  config,
   manageAlternateThemeClasses,
   manageDarkModeClasses,
   secondaryToggleEnabled,
   writeLocalStorage,
 } from './utils.ts';
-
-declare global {
-  interface Window {
-    SITEIFY_CONFIG?: {
-      secondaryToggle?: {
-        disabled?: boolean;
-        className?: string;
-      };
-      headerLink?: {
-        text?: string;
-        url?: string;
-      };
-    };
-  }
-}
 
 function Header() {
   const {
@@ -30,7 +14,7 @@ function Header() {
     alternateThemeClass,
     darkMode: initialDarkModeValue,
     alternateTheme: initialAlternateThemeValue,
-  } = config();
+  } = window.config();
   const [darkMode, setDarkMode] = useState(initialDarkModeValue);
   const [alternateTheme, setAlternateTheme] = useState(initialAlternateThemeValue);
 
@@ -59,10 +43,6 @@ function Header() {
     manageAlternateThemeClasses(alternateTheme, alternateThemeClass);
     writeLocalStorage(darkMode, alternateTheme);
   }, [darkMode, alternateTheme]);
-
-  useEffect(() => {
-    document.body.classList.remove('hidden');
-  }, []);
 
   return (
     <div>

--- a/src/components/header/utils.ts
+++ b/src/components/header/utils.ts
@@ -1,70 +1,25 @@
 export const writeLocalStorage = (darkMode: boolean, alternateTheme: boolean) => {
-  localStorage.setItem(SITEIFY_THEME_SELECTION_KEY, JSON.stringify({ darkMode, alternateTheme }));
+  localStorage.setItem(window.SITEIFY_THEME_SELECTION_KEY, JSON.stringify({ darkMode, alternateTheme }));
 };
 
 export const manageDarkModeClasses = (darkMode: boolean) => {
   if (darkMode) {
-    document.body.classList.remove('light');
-    document.body.classList.add('dark');
+    document.documentElement.classList.remove('light');
+    document.documentElement.classList.add('dark');
   } else {
-    document.body.classList.remove('dark');
-    document.body.classList.add('light');
+    document.documentElement.classList.remove('dark');
+    document.documentElement.classList.add('light');
   }
 };
 
 export const manageAlternateThemeClasses = (alternateTheme: boolean, alternateThemeClass: string) => {
   if (alternateTheme) {
-    document.body.classList.add(alternateThemeClass);
+    document.documentElement.classList.add(alternateThemeClass);
   } else {
-    document.body.classList.remove(alternateThemeClass);
+    document.documentElement.classList.remove(alternateThemeClass);
   }
 };
-
-const SITEIFY_THEME_SELECTION_KEY = 'siteifyThemeSelection';
 
 export const secondaryToggleEnabled = (siteifyConfig: (typeof window)['SITEIFY_CONFIG']) => {
   return !siteifyConfig?.secondaryToggle?.disabled;
-};
-
-interface SiteifySelections {
-  darkMode: boolean;
-  alternateTheme: boolean;
-}
-
-export const isSiteifySelections = (v: unknown): v is SiteifySelections => {
-  if (typeof v !== 'object' || v === null) return false;
-  const { darkMode, alternateTheme } = v as { darkMode: unknown; alternateTheme: unknown };
-  return [darkMode, alternateTheme].every((value) => typeof value === 'boolean');
-};
-
-export const siteifySelections = (userPrefersDark: boolean, secondaryToggleEnabled: boolean): SiteifySelections => {
-  const DEFAULT_SELECTIONS: SiteifySelections = {
-    darkMode: userPrefersDark,
-    alternateTheme: false,
-  };
-  try {
-    const selectionsString = localStorage.getItem(SITEIFY_THEME_SELECTION_KEY) || '';
-    const selectionsObj = JSON.parse(selectionsString);
-    if (isSiteifySelections(selectionsObj)) {
-      return secondaryToggleEnabled ? selectionsObj : { ...selectionsObj, alternateTheme: false };
-    } else {
-      throw new Error('selections did not match expected shape');
-    }
-  } catch {
-    return DEFAULT_SELECTIONS;
-  }
-};
-
-export const config = () => {
-  // get system dark/light preference
-  const userPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-
-  // grab configuration for the site - (stored on window, configured on a per-site basis via script tag)
-  const siteifyConfig = window?.SITEIFY_CONFIG;
-  const alternateThemeClass: string = siteifyConfig?.secondaryToggle?.className || 'haxor';
-
-  // read local storage for user selections
-  const selections: SiteifySelections = siteifySelections(userPrefersDark, secondaryToggleEnabled(siteifyConfig));
-
-  return { siteifyConfig, alternateThemeClass, ...selections };
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,7 +15,7 @@ declare global {
       };
     };
     SITEIFY_THEME_SELECTION_KEY: string;
-    config: () => {
+    siteifyThemeConfig: () => {
       siteifyConfig: (typeof window)['SITEIFY_CONFIG'];
       alternateThemeClass: string;
       darkMode: boolean;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,28 @@ import { render } from 'preact';
 import './index.css';
 import { App } from './app.tsx';
 
+declare global {
+  interface Window {
+    SITEIFY_CONFIG?: {
+      secondaryToggle?: {
+        disabled?: boolean;
+        className?: string;
+      };
+      headerLink?: {
+        text?: string;
+        url?: string;
+      };
+    };
+    SITEIFY_THEME_SELECTION_KEY: string;
+    config: () => {
+      siteifyConfig: (typeof window)['SITEIFY_CONFIG'];
+      alternateThemeClass: string;
+      darkMode: boolean;
+      alternateTheme: boolean;
+    };
+  }
+}
+
 const container = document.body.querySelector('#page');
 if (container) {
   container.insertBefore(document.createElement('header'), container.firstChild);
@@ -9,4 +31,3 @@ if (container) {
     render(<App />, container.firstChild);
   }
 }
-

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -1,4 +1,4 @@
-body.light {
+html.light {
   --color-dark-900: hsl(0, 0%, 16%);
   --color-dark-800: hsl(0, 0%, 21%);
   --color-mauve-700: hsl(344, 47%, 30%);
@@ -35,7 +35,7 @@ body.light {
   --code-theme-color-comment: var(--color-sand-500);
 }
 
-body.dark {
+html.dark {
   --color-grey-900: hsl(0, 0%, 16%);
   --color-grey-800: hsl(0, 0%, 21%);
   --color-grey-500: hsl(0, 0%, 58%);
@@ -65,7 +65,7 @@ body.dark {
   --code-theme-color-comment: var(--color-grey-500);
 }
 
-body.light.haxor {
+html.light.haxor {
   --color-white: #ffffff;
   --color-black: #000000;
   --color-green: #00ff00;
@@ -90,7 +90,7 @@ body.light.haxor {
   --code-theme-color-comment: var(--color-white);
 }
 
-body.dark.haxor {
+html.dark.haxor {
   --color-green-900: hsl(144, 100%, 3%);
   --color-green-800: hsl(142, 100%, 6%);
   --color-green-600: hsl(140, 100%, 15%);


### PR DESCRIPTION
We want theme classes applied ASAP. Having this logic in a script tag ensures it will be run before HTML is parsed. Moving theme classes to the `html` element instead of the `body` element ensures we can access it before HTML is parsed.